### PR TITLE
Treat JSX transpiler errors like JSHint errors

### DIFF
--- a/jsxhint.js
+++ b/jsxhint.js
@@ -50,7 +50,8 @@ function transformJSX(fileStream, fileName, cb){
 
       cb(null, source);
     } catch(e) {
-      cb(new Error(fileName +' contained an illegal character'.red));
+      e.fileName = fileName;
+      cb(e);
     }
   }
 

--- a/test/fixtures/test_malformed.jsx
+++ b/test/fixtures/test_malformed.jsx
@@ -1,0 +1,9 @@
+'use strict';
+
+var React = require('react-tools/build/modules/React');
+
+module.exports = React.createClass({
+  render: function(){
+    return <div;
+  }
+});

--- a/test/test.js
+++ b/test/test.js
@@ -62,3 +62,26 @@ test('Error output should match jshint', function(t){
     });
   }
 });
+
+test('JSX transpiler error should look like JSHint output', function(t){
+  t.plan(2);
+  var jsxhint_proc = child_process.fork('../cli', ['fixtures/test_malformed.jsx'], {silent: true});
+
+  drain_stream(jsxhint_proc.stdout, function(err, jsxhintOut){
+    t.ifError(err);
+    t.equal(jsxhintOut, 'fixtures/test_malformed.jsx: line 7, col 16, Unexpected token ;\n\n1 error\n', 'JSXHint output should display the transplier error through the JSHint reporter.');
+  });
+
+  function drain_stream(stream, cb){
+    var buf = '';
+    stream.on('data', function(chunk){
+      buf += chunk;
+    });
+    stream.on('error', function(e){
+      cb(e);
+    });
+    stream.on('end', function(){
+      cb(null, buf);
+    });
+  }
+});


### PR DESCRIPTION
Prior to this commit, any error that occurred within the JSX transpiler would
crash the process. Obviously this is not very helpful as all linting is thrown
out the window. This commit captures any error thrown in the transpile step and
transfers it to the JSHint reporter so it will be displayed like any other
linter error.
