### PR TITLE
Create temporary files in os.tmpdir()

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-tools": "~0.8.0",
     "jstransform": "~2.0.1",
     "through": "~2.3.4",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "mkdirp": "~0.3.5"
   },
   "devDependencies": {
     "tap": "~0.4.6"


### PR DESCRIPTION
Creating temporary files in the working tree can cause havok when it comes to
file watchers. This commit will save all temp files in the directory specified
by `os.tmpdir()`, so it _should_ be safe on Windows too. It also ensures to copy
over the parent `.jshintrc` and also `package.json` as JSHint CLI uses these for
options.
