### PR TITLE
Upgrade react-tools to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "jshint": "~2.3.0",
-    "react-tools": "~0.8.0",
+    "react-tools": "~0.9.0",
     "jstransform": "~2.0.1",
     "through": "~2.3.4",
     "async": "~0.2.9",


### PR DESCRIPTION
According to http://facebook.github.io/react/blog/2014/02/20/react-v0.9.html this fixes the spacing issues that were making JSHint complain.
