### PR TITLE
pass through jshint success/fail for exit code

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -121,7 +121,7 @@ try {
         var done = function(passed){
           if (passed == null) return;
           unlinkTemp(files);
-          cb();
+          cb(passed);
         };
         done(jshintcli.originalRun(opts, done));
       });

--- a/test/test.js
+++ b/test/test.js
@@ -72,7 +72,7 @@ test('JSX transpiler error should look like JSHint output, instead of crashing',
 
   drain_stream(jsxhint_proc.stdout, function(err, jsxhintOut){
     t.ifError(err);
-    t.equal(jsxhintOut, 'fixtures/test_malformed.jsx: line 7, col 16, Unexpected token ;\n\n1 error\n',
+    t.equal(jsxhintOut, 'fixtures/test_malformed.jsx: line 8, col 16, Unexpected token ;\n\n1 error\n',
       'JSXHint output should display the transplier error through the JSHint reporter.');
   });
 });
@@ -83,6 +83,6 @@ test('JSX transpiler error should look like JSHint output', function(t){
 
   drain_stream(jsxhint_proc.stdout, function(err, jsxhintOut){
     t.ifError(err);
-    t.equal(jsxhintOut, 'fixtures/test_malformed.jsx: line 7, col 16, Unexpected token ;\n\n1 error\n', 'JSXHint output should display the transplier error through the JSHint reporter.');
+    t.equal(jsxhintOut, 'fixtures/test_malformed.jsx: line 8, col 16, Unexpected token ;\n\n1 error\n', 'JSXHint output should display the transplier error through the JSHint reporter.');
   });
 });


### PR DESCRIPTION
For things like git pre-commit hooks it is super nice to have exit codes as opposed to checking the output.

Also fixed two tests.
