### PR TITLE
Enable ES6 features for JSX transform

### DIFF
--- a/jsxhint.js
+++ b/jsxhint.js
@@ -46,7 +46,7 @@ function transformJSX(fileStream, fileName, cb){
       }
 
       if (hasExtension || hasDocblock) {
-        source = react.transform(source);
+        source = react.transform(source, {harmony: true});
       }
 
       cb(null, source);


### PR DESCRIPTION
This makes jsxhint not complain about the use of ES6 features. This could be added behind a flag, but this is simpler and my guess is no one will write ES6 code by accident.
