### PR TITLE
Fix Error: EMFILE, too many open files

### DIFF
--- a/jsxhint.js
+++ b/jsxhint.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-var fs = require('fs');
+var fs = require('graceful-fs');
 var path = require('path');
 
 var jshint = require('jshint').JSHINT;

--- a/package.json
+++ b/package.json
@@ -31,13 +31,14 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "jshint": "~2.5.1",
-    "react-tools": "~0.10.0",
-    "jstransform": "~4.0.1",
-    "through": "~2.3.4",
     "async": "~0.8.0",
+    "graceful-fs": "^3.0.2",
+    "jshint": "~2.5.1",
+    "jstransform": "~4.0.1",
     "mkdirp": "~0.5.0",
-    "rimraf": "~2.2.8"
+    "react-tools": "~0.10.0",
+    "rimraf": "~2.2.8",
+    "through": "~2.3.4"
   },
   "devDependencies": {
     "tap": "~0.4.9",


### PR DESCRIPTION
When running jsxhint on all of my components like `jsxhint
path/to/components/**/*.jsx`, I am getting the following error:

> Error: EMFILE, too many open files

After some quick Googling, it looks like you can drop in graceful-fs as
a replacement for fs and this will go away. I installed this by executing:

```
npm install --save graceful-fs
```

http://stackoverflow.com/a/15934766/18986
https://github.com/isaacs/node-graceful-fs

Fixes #14
