### PR TITLE
react v0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-tools": "~0.11.0",
     "jstransform": "~6.0.1",
     "through": "~2.3.4",
-    "async": "~0.8.0",
+    "async": "~0.9.0",
     "mkdirp": "~0.5.0",
     "rimraf": "~2.2.8",
     "graceful-fs": "~3.0.2",


### PR DESCRIPTION
React v0.11 introduced [JSX namespacing](http://facebook.github.io/react/blog/2014/07/17/react-v0.11.html#jsx-namespacing). The previous version of React causes `JSXHint` to report errors when you try to use them. 
