### PR TITLE
Strip Flow type annotations when transforming

### DIFF
--- a/jsxhint.js
+++ b/jsxhint.js
@@ -43,7 +43,7 @@ function transformJSX(fileStream, fileName, opts, cb){
     if (opts['--6to5']) {
       return to5.transform(source).code;
     } else {
-      return react.transform(source, {harmony: false});
+      return react.transform(source, {harmony: false, stripTypes: true});
     }
   }
 

--- a/test/fixtures/test_flow.js
+++ b/test/fixtures/test_flow.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+var myFunction = function(text: string, length: number): string {
+  return string.substr(0, length);
+}
+
+module.exports = myFunction;

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,13 @@ function drain_stream(stream, cb){
   });
 }
 
+test('Strip flow types', function(t){
+  t.plan(2);
+  jsxhint.transformJSX('./fixtures/test_flow.js', {}, function(err, data){
+    t.ifError(err);
+    t.equal(data.match(/text: string/), null, 'Flow types were not properly stripped.');
+  });
+});
 
 test('Convert JSX to JS', function(t){
   t.plan(20);


### PR DESCRIPTION
Facebook has recently released Flow, a static type checker for
JavaScript.

  http://flowtype.org/

Flow augments the standard JavaScript syntax with type annotations that
need to be removed before passing the code on to things that expect
actual JavaScript. The react-tools project includes a stripTypes option,
that we can just turn on to process this code correctly.

This commit allows people to use Flow with jsxhint by including the
stripTypes option when performing the react-tools transformation.

Closes #35
