### PR TITLE
Remove unused deps

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -14,10 +14,7 @@ var jsxhint = require('./jsxhint');
 var jshintcli = require('jshint/src/cli');
 var fork = require('child_process').fork;
 var through = require('through');
-var fs = require('fs');
-var path = require('path');
 var rimraf = require('rimraf');
-var extend = require('extend');
 
 // The jshint call will throw an error if it encounters an option that it does
 // not recognize. Therefore, we need to filter out jsxhint options before

--- a/jsxhint.js
+++ b/jsxhint.js
@@ -13,23 +13,17 @@
 var fs = require('graceful-fs');
 var path = require('path');
 
-var jshint = require('jshint').JSHINT;
-var gather = require('jshint/src/cli').gather;
 var react = require('react-tools');
 try {
   var babel = require('babel');
 } catch(e) {
   // ignore
 }
-var through = require('through');
-var fork = require('child_process').fork;
 var async = require('async');
 var path = require('path');
 var mkdirp = require('mkdirp');
 var debug = require('debug')('jsxhint');
 
-var currFile = require.main ? require.main.filename : undefined;
-var prjRoot = path.dirname(currFile || process.cwd());
 // Check map for copied support files (package.json, .jshintrc) for a speedup.
 var checkedSupportFiles = {};
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "async": "~0.9.0",
     "debug": "~2.1.0",
-    "extend": "^2.0.0",
     "graceful-fs": "~3.0.5",
     "jshint": "^2.6.0",
     "mkdirp": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "extend": "^2.0.0",
     "graceful-fs": "~3.0.5",
     "jshint": "^2.6.0",
-    "jstransform": "~8.2.0",
     "mkdirp": "~0.5.0",
     "react-tools": "^0.12.1",
     "rimraf": "~2.2.8",


### PR DESCRIPTION
I was messing around with `react@0.13.0-beta.2` and I kept also having to change the `jstransform` version, by removing it as a dependency, it makes updating to new versions a one line change. Also caught a few extras along the way.