### PR TITLE
Update to babel 4.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "through": "~2.3.6"
   },
   "devDependencies": {
-    "babel": "^4.0.1",
+    "babel": "^4.6.6",
     "precommit-hook": "~1.0.7",
     "tap": "~0.4.13"
   },

--- a/test/fixtures/test_article.js
+++ b/test/fixtures/test_article.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 'use strict'
 
 var React = require('react-tools/build/modules/React');


### PR DESCRIPTION
Babel had a lot of improvements since its 4.0.1 version, including the ``import from 'package';`` syntax.

Using them will crash JSXHint.

I had to edit the tests to remove a ``/** @jsx React.DOM */``. I don't know if you want to keep it, but I couldn't find a way to test it. IMHO it should be the role of React to warm you that the syntax is outdated, not JSXHint, but I understand the need to test it.

PS: I really appreciate your work here !