### PR TITLE
Surface --es6-module options from react-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "0.10"
+sudo: false  # use container-based architecture

--- a/cli.js
+++ b/cli.js
@@ -22,7 +22,14 @@ var glob = require('glob-all');
 // calling jshint. Because jsxhint is run in part of a callback of jshint after
 // this check, we need to store jsxhint options someplace globally so we can
 // access them inside the callback.
-var acceptedJSXHintOptions = ['--jsx-only', '--babel', '--babel-experimental', '--harmony'];
+var acceptedJSXHintOptions = [
+  '--jsx-only',
+  '--babel',
+  '--babel-experimental',
+  '--harmony',
+  '--es6module',
+  '--non-strict-es6module'
+];
 var jsxhintOptions = {};
 
 /**
@@ -47,6 +54,8 @@ function showHelp(){
                '                            Useful if you are using es7-async, etc.\n');
     this.queue('      --harmony          Use react esprima with ES6 transformation support.\n' +
                '                         Useful if you are using both es6-class and react.\n');
+    this.queue('      --es6module             Pass the --es6module flag to react tools.\n');
+    this.queue('      --non-strict-es6module  Pass this flag to react tools.\n');
   });
   jshint_proc.stderr.pipe(ts).pipe(process.stderr);
 }

--- a/jsxhint.js
+++ b/jsxhint.js
@@ -41,7 +41,12 @@ function transformJSX(fileStream, fileName, opts, cb){
     if (opts['--babel'] || opts['--babel-experimental']) {
       return babel.transform(source, {experimental: opts['--babel-experimental'] || false}).code;
     } else {
-      return react.transform(source, {harmony: opts['--harmony'], stripTypes: true});
+      return react.transform(source, {
+        harmony: opts['--harmony'],
+        stripTypes: true,
+        nonStrictEs6module: opts['--non-strict-es6module'] || false,
+        es6module: opts['--es6module'] || false
+      });
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "graceful-fs": "~3.0.5",
     "jshint": "^2.6.0",
     "mkdirp": "~0.5.0",
-    "react-tools": "^0.12.1",
+    "react-tools": "^0.13.1",
     "rimraf": "~2.2.8",
     "through": "~2.3.6"
   },

--- a/test/fixtures/test_flow_import.js
+++ b/test/fixtures/test_flow_import.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+import type * as URI from 'URI';
+
+var myFunction = function(text: string, length: number): string {
+  return string.substr(0, length);
+}
+
+module.exports = myFunction;

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,22 @@ test('Strip flow types', function(t){
   });
 });
 
+test('Strip flow types with modules', function(t){
+  t.plan(2);
+  jsxhint.transformJSX('./fixtures/test_flow_import.js', { '--es6module': true }, function(err, data){
+    t.ifError(err);
+    t.equal(data.match(/import/), null, 'Flow types were not properly stripped.\n' + data);
+  });
+});
+
+test('Strip flow types with non-strict modules', function(t){
+  t.plan(2);
+  jsxhint.transformJSX('./fixtures/test_flow_import.js', {'--non-strict-es6module': true}, function(err, data){
+    t.ifError(err);
+    t.equal(data.match(/import/), null, 'Flow types were not properly stripped.\n' + data);
+  });
+});
+
 test('Convert JSX to JS', function(t){
   t.plan(28);
   jsxhint.transformJSX('./fixtures/test_article_without_pragma.js', { '--jsx-only' : true }, function(err, data){


### PR DESCRIPTION
This is required to make [`import type` statements][1] work in jsxhint.

This builds on #55 

I've also taken the opportunity to turn on Travis [container-based architecture][2], which has no downsides and has the big upside of making your builds start much faster.

[1]: http://flowtype.org/blog/2015/02/18/Import-Types.html
[2]: http://docs.travis-ci.com/user/workers/container-based-infrastructure/