### PR TITLE
Allow showing transform errors for non-jsx files

### DIFF
--- a/jsxhint.js
+++ b/jsxhint.js
@@ -58,10 +58,10 @@ function transformJSX(fileStream, fileName, opts, cb){
       try {
         return transformSource(source, opts);
       } catch(e) {
-        // Only throw an error if this was definitely a jsx file.
         // Seems that esprima has some problems with some js syntax.
-        if (hasExtension) {
-          console.error("Error while transforming jsx in file " + fileName + "\n", e.stack);
+        if (opts['--transform-errors'] === 'always' ||
+            (opts['--transform-errors'] !== 'never' && hasExtension)) {
+          console.error("Error while transforming file " + fileName + "\n", e.stack);
           throw utils.transformError(fileName, e, opts);
         }
       }


### PR DESCRIPTION
If you use JSX without the `*.jsx` extension and introduce a syntax error, `jsxhint` will currently pass through the untransformed code to `jshint` and blow up on all the invalid JSX (and Harmony or Flow) syntax — not very helpful.

This changes `jsxhint` to preserve the sensible default (of only throwing for `*.jsx` extensions) while allowing the configuration to throw for all errors (even on non-`*.jsx` files).