### PR TITLE
Add "--babel-disable-strict" option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ JSXHint Options:
       --babel            Use babel (6to5) instead of react esprima.
                          Useful if you are using es6-module, etc. You must
                          install the module `babel` manually with npm.
+      --babel-disable-strict  Make babel don't automatically place a "use strict"
+                              directive at the top of a transpiled source.
       --babel-experimental  Use babel with experimental support for ES7.
                             Useful if you are using es7-async, etc.
       --harmony          Use react esprima with ES6 transformation support.

--- a/cli.js
+++ b/cli.js
@@ -29,6 +29,7 @@ var debug = require('debug')('jsxhint');
 // access them inside the callback.
 var acceptedJSXHintOptions = {
   '--babel': false,
+  '--babel-disable-strict': false,
   '--babel-experimental': false,
   '--es6module': false,
   '--harmony': false,
@@ -56,6 +57,8 @@ function showHelp(){
     this.queue('      --babel            Use babel (6to5) instead of react esprima.\n' +
                '                         Useful if you are using es6-module, etc. You must \n' +
                '                         install the module `babel` manually with npm.\n');
+    this.queue('      --babel-disable-strict  Make babel don\'t automatically place a "use strict"\n' +
+               '                              directive at the top of a transpiled source.\n');
     this.queue('      --babel-experimental  Use babel with experimental support for ES7.\n' +
                '                            Useful if you are using es7-async, etc.\n');
     this.queue('      --harmony          Use react esprima with ES6 transformation support.\n' +
@@ -64,6 +67,8 @@ function showHelp(){
     this.queue('      --non-strict-es6module  Pass this flag to react tools.\n');
     this.queue('      --transform-errors STRING   Whether to fail on transform errors.\n' +
                '                                  Valid: always, jsx, never (default: jsx)');
+    // Terminate help with a newline
+    this.queue('\n');
   });
   jshint_proc.stderr.pipe(ts).pipe(process.stderr);
 }

--- a/jsxhint.js
+++ b/jsxhint.js
@@ -73,7 +73,11 @@ function transformJSX(fileStream, fileName, opts, cb){
 
 function transformSource(source, opts){
   if (opts['--babel'] || opts['--babel-experimental']) {
-    return babel.transform(source, {stage: opts['--babel-experimental'] ? 0 : 2, retainLines: true}).code;
+    return babel.transform(source, {
+      stage: opts['--babel-experimental'] ? 0 : 2,
+      blacklist: opts['--babel-disable-strict'] ? ['strict'] : [],
+      retainLines: true
+    }).code;
   } else {
     return jstransform.transform(source, {
       react: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsxhint",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Wrapper for JSHint to allow hinting of JSX files",
   "main": "jsxhint.js",
   "bin": "./cli.js",

--- a/test/fixtures/test_disable_strict.jsx
+++ b/test/fixtures/test_disable_strict.jsx
@@ -1,0 +1,7 @@
+var React = require('react-tools/build/modules/React');
+
+module.exports = React.createClass({
+  render: function() {
+    return <div></div>;
+  }
+});

--- a/test/test.js
+++ b/test/test.js
@@ -245,3 +245,15 @@ test('overrides', function(t) {
       'use_strict override should squelch the strict error in test_overrides.js.');
   });
 });
+
+test('--babel-disable-strict option', function(t) {
+  t.plan(2);
+
+  runJSXHint(['--babel', 'fixtures/test_disable_strict.jsx'], function(err, jsxhintOut) {
+    t.equal(jsxhintOut, '');
+  });
+
+  runJSXHint(['--babel', '--babel-disable-strict', 'fixtures/test_disable_strict.jsx'], function(err, jsxhintOut) {
+    t.inequal(jsxhintOut, '');
+  });
+});


### PR DESCRIPTION
With this option babel will not automatically add a "use strict" at the top of a transpiled source. This allows to lint code that for some reason violates Strict Mode.