### PR TITLE
Upgrade jstransform to 11.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fs-extra": "^0.16.5",
     "glob-all": "^3.0.1",
     "jshint": "^2.6.0",
-    "jstransform": "^11.0.1",
+    "jstransform": "^11.0.2",
     "through": "~2.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
jstransform 11.0.2 has merged https://github.com/facebook/jstransform/pull/105, which will fix the use of option `quotmark:double` https://github.com/STRML/JSXHint/issues/72

Still no perfect fix for singlequote https://github.com/STRML/JSXHint/issues/21, but better fixing one of them than neither