### PR TITLE
Use babel-core instead of babel

### DIFF
--- a/jsxhint.js
+++ b/jsxhint.js
@@ -18,7 +18,7 @@ var debug = require('debug')('jsxhint');
 
 var jstransform = require('jstransform/simple');
 try {
-  var babel = require('babel');
+  var babel = require('babel-core');
 } catch(e) {
   // ignore
 }
@@ -41,7 +41,7 @@ function transformJSX(fileStream, fileName, opts, cb){
   }
 
   if (!babel && (opts['--babel'] || opts['--babel-experimental'])) {
-    throw new Error("Optional babel parser not installed. Please `npm install [-g] babel`.");
+    throw new Error("Optional babel parser not installed. Please `npm install [-g] babel-core`.");
   }
 
   // Allow passing strings into this method e.g. when using it as a lib


### PR DESCRIPTION
When debugging why my system always complained about not having babel installed I got the following error:

```
[Error: The node API for `babel` has been moved to `babel-core`.]
```

By installing then using babel-core on jsxhint it behaved as expected