### PR TITLE
Use `tmpdir` first to solve Node 7 deprecation

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -16,7 +16,7 @@ var utils = module.exports = {
    * Places all temp files here.
    * @type {String}
    */
-  tmpdir: path.join((os.tmpDir || os.tmpdir)(), 'jsxhint', String(process.pid)),
+  tmpdir: path.join((os.tmpdir || os.tmpDir)(), 'jsxhint', String(process.pid)),
 
   /**
    * Drain a readstream into a string.


### PR DESCRIPTION
When used with Node v7, The following warning message is displayed.
```
(node:62373) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
```
This patch aims to get rid of this deprecation warning on Node 7